### PR TITLE
fix(claude-code): skill name field must match folder name for /skill commands

### DIFF
--- a/skills/convex-agents/SKILL.md
+++ b/skills/convex-agents/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Agents
+name: convex-agents
+displayName: Convex Agents
 description: Building AI agents with the Convex Agent component including thread management, tool integration, streaming responses, RAG patterns, and workflow orchestration
 version: 1.0.0
 author: Convex

--- a/skills/convex-best-practices/SKILL.md
+++ b/skills/convex-best-practices/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Best Practices
+name: convex-best-practices
+displayName: Convex Best Practices
 description: Guidelines for building production-ready Convex apps covering function organization, query patterns, validation, TypeScript usage, error handling, and the Zen of Convex design philosophy
 version: 1.0.0
 author: Convex

--- a/skills/convex-component-authoring/SKILL.md
+++ b/skills/convex-component-authoring/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Component Authoring
+name: convex-component-authoring
+displayName: Convex Component Authoring
 description: How to create, structure, and publish self-contained Convex components with proper isolation, exports, and dependency management
 version: 1.0.0
 author: Convex

--- a/skills/convex-cron-jobs/SKILL.md
+++ b/skills/convex-cron-jobs/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Cron Jobs
+name: convex-cron-jobs
+displayName: Convex Cron Jobs
 description: Scheduled function patterns for background tasks including interval scheduling, cron expressions, job monitoring, retry strategies, and best practices for long-running tasks
 version: 1.0.0
 author: Convex

--- a/skills/convex-file-storage/SKILL.md
+++ b/skills/convex-file-storage/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex File Storage
+name: convex-file-storage
+displayName: Convex File Storage
 description: Complete file handling including upload flows, serving files via URL, storing generated files from actions, deletion, and accessing file metadata from system tables
 version: 1.0.0
 author: Convex

--- a/skills/convex-functions/SKILL.md
+++ b/skills/convex-functions/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Functions
+name: convex-functions
+displayName: Convex Functions
 description: Writing queries, mutations, actions, and HTTP actions with proper argument validation, error handling, internal functions, and runtime considerations
 version: 1.0.0
 author: Convex

--- a/skills/convex-http-actions/SKILL.md
+++ b/skills/convex-http-actions/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex HTTP Actions
+name: convex-http-actions
+displayName: Convex HTTP Actions
 description: External API integration and webhook handling including HTTP endpoint routing, request/response handling, authentication, CORS configuration, and webhook signature validation
 version: 1.0.0
 author: Convex

--- a/skills/convex-migrations/SKILL.md
+++ b/skills/convex-migrations/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Migrations
+name: convex-migrations
+displayName: Convex Migrations
 description: Schema migration strategies for evolving applications including adding new fields, backfilling data, removing deprecated fields, index migrations, and zero-downtime migration patterns
 version: 1.0.0
 author: Convex

--- a/skills/convex-realtime/SKILL.md
+++ b/skills/convex-realtime/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Realtime
+name: convex-realtime
+displayName: Convex Realtime
 description: Patterns for building reactive apps including subscription management, optimistic updates, cache behavior, and paginated queries with cursor-based loading
 version: 1.0.0
 author: Convex

--- a/skills/convex-schema-validator/SKILL.md
+++ b/skills/convex-schema-validator/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Schema Validator
+name: convex-schema-validator
+displayName: Convex Schema Validator
 description: Defining and validating database schemas with proper typing, index configuration, optional fields, unions, and migration strategies for schema changes
 version: 1.0.0
 author: Convex

--- a/skills/convex-security-audit/SKILL.md
+++ b/skills/convex-security-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Security Audit
+name: convex-security-audit
+displayName: Convex Security Audit
 description: Deep security review patterns for authorization logic, data access boundaries, action isolation, rate limiting, and protecting sensitive operations
 version: 1.0.0
 author: Convex

--- a/skills/convex-security-check/SKILL.md
+++ b/skills/convex-security-check/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Convex Security Check
+name: convex-security-check
+displayName: Convex Security Check
 description: Quick security audit checklist covering authentication, function exposure, argument validation, row-level access control, and environment variable handling
 version: 1.0.0
 author: Convex

--- a/skills/convex/SKILL.md
+++ b/skills/convex/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: convex
+displayName: Convex Development
+description: Umbrella skill for all Convex development patterns. Routes to specific skills like convex-functions, convex-realtime, convex-agents, etc.
+version: 1.0.0
+author: Convex
+tags: [convex, backend, database, realtime]
+---
+
+# Convex Development Skills
+
+This is an index skill for Convex development. Use specific skills for detailed guidance:
+
+## Core Development
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| Functions | `/convex-functions` | Writing queries, mutations, actions |
+| Schema | `/convex-schema-validator` | Defining database schemas and validators |
+| Realtime | `/convex-realtime` | Building reactive subscriptions |
+| HTTP Actions | `/convex-http-actions` | Webhooks and HTTP endpoints |
+
+## Data & Storage
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| File Storage | `/convex-file-storage` | File uploads, serving, storage |
+| Migrations | `/convex-migrations` | Schema evolution, data backfills |
+
+## Advanced Patterns
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| Agents | `/convex-agents` | Building AI agents with tools |
+| Cron Jobs | `/convex-cron-jobs` | Scheduled background tasks |
+| Components | `/convex-component-authoring` | Reusable Convex packages |
+
+## Security
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| Security Check | `/convex-security-check` | Quick security audit checklist |
+| Security Audit | `/convex-security-audit` | Deep security review |
+
+## Guidelines
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| Best Practices | `/convex-best-practices` | General patterns and guidelines |
+
+## Quick Start
+
+For most tasks:
+1. Start with `/convex-best-practices` for general patterns
+2. Use `/convex-functions` for writing backend logic
+3. Use `/convex-schema-validator` for data modeling
+4. Use specific skills as needed for your use case
+
+## Documentation
+
+- Primary: https://docs.convex.dev
+- LLM-optimized: https://docs.convex.dev/llms.txt


### PR DESCRIPTION
Fix meta headers for proper `/convex*` SKILLS.md headers to work in claude code.

